### PR TITLE
Nodemailer Setup + emailBuilder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "express": "^4.18.2",
         "json-server": "^0.17.4",
         "morgan": "^1.10.0",
+        "nodemailer": "^6.9.7",
         "nodemon": "^3.0.1",
         "pg": "^8.11.3",
         "pg-hstore": "^2.3.4",
@@ -1205,6 +1206,14 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.7.tgz",
+      "integrity": "sha512-rUtR77ksqex/eZRLmQ21LKVH5nAAsVicAtAYudK7JgwenEDZ0UIQ1adUGqErz7sMkWYxWTTU1aeP2Jga6WQyJw==",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "express": "^4.18.2",
     "json-server": "^0.17.4",
     "morgan": "^1.10.0",
+    "nodemailer": "^6.9.7",
     "nodemon": "^3.0.1",
     "pg": "^8.11.3",
     "pg-hstore": "^2.3.4",

--- a/src/Utils/emailBuilder.js
+++ b/src/Utils/emailBuilder.js
@@ -1,0 +1,5 @@
+const emailBuilder = () => {
+
+}
+
+module.exports = emailBuilder;

--- a/src/Utils/emailBuilder.js
+++ b/src/Utils/emailBuilder.js
@@ -1,5 +1,12 @@
-const emailBuilder = () => {
+const { SMTP_ADMINEMAIL } = process.env;
 
+const emailBuilder = (to, subject, message) => {
+    return {
+        from: 'group.creva@gmail.com',
+        to: to = 'ADMIN' ? SMTP_ADMINEMAIL : to,
+        subject: subject,
+        text: message
+    }
 }
 
 module.exports = emailBuilder;

--- a/src/nodemailer.js
+++ b/src/nodemailer.js
@@ -1,0 +1,12 @@
+const nodemailer = require('nodemailer');
+const { SMTP_HOST, SMTP_USERNAME, SMTP_PASSWORD } = process.env;
+
+const transporter = nodemailer.createTransport({
+    service: SMTP_HOST,
+    auth: {
+        user: SMTP_USERNAME,
+        pass: SMTP_PASSWORD
+    }
+})
+
+module.exports = transporter;


### PR DESCRIPTION
CONFIGURACIÓN **_.env_**:

```
SMTP_ADMINEMAIL = pongan su correo
SMTP_HOST = gmail
SMTP_USERNAME = group.creva@gmail.com
SMTP_PASSWORD = oaos mzvh wvas xsyl
```

USO:

Importar **_transporter_** y **_emailBuilder_** y usar el método **_sendMail_**. Ejemplo:

```
const [service, created] = await Service.findOrCreate({ where: { name: serviceInfo.name }, defaults:{ ...serviceInfo } });
const { Service } = require('../../db');
const transporter = require('../../nodemailer'); <-----------------------------------
const emailBuilder = require('../../Utils/emailBuilder'); <---------------------------
const titleCase = require('../../Utils/titleCase');

const postServiceController = async (serviceInfo) => {
    serviceInfo = {
        ...serviceInfo,
        name: await titleCase(serviceInfo.name)
    };
    const [service, created] = await Service.findOrCreate({ where: { name: serviceInfo.name }, defaults:{ ...serviceInfo } });
    if (created) { <------------------------------
        transporter.sendMail(emailBuilder('ADMIN', 'Servicio creado', `El servicio ${serviceInfo.name} fue creado correctamente.`));
        return service;
    }
    else throw new Error ('Ya existe un servicio con ese nombre.')
}

module.exports = postServiceController;
```

emailBuilder recibe tres parámetros, en orden:

- Correo del receptor *
- Asunto.
- Mensaje.

*Si en el parámetro del correo del receptor se ingresa el string "ADMIN", toma el correo configurado como administrador en .env. Esto hay que mejorarlo para que tome el correo del admin desde la DB.

El próximo paso sería crear las plantillas HTML para las diferentes notificaciones, pero con esto ya se puede ir armando el envío del mail en los controllers.