### PR TITLE
db Fixed, asociaciones OK

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -25,12 +25,12 @@ const {
 } = sequelize.models;
 
 //! define associations
-User.hasMany(Review);
-Review.belongsTo(User);
-User.hasMany(Transaction);
-Transaction.belongsTo(User);
-Service.hasMany(Review);
-Review.belongsTo(Service);
+User.hasMany(Review, {as: "reviews", foreignKey: "userId"});
+Review.belongsTo(User, {as: "user"});
+User.hasMany(Transaction, {as: "buys", foreignKey: "userId"});
+Transaction.belongsTo(User, {as: "user"});
+Service.hasMany(Review, {as: "reviews", foreignKey: "serviceId"});
+Review.belongsTo(Service, {as: "service"});
 Service.belongsToMany(Transaction, { through: 'Services_Transactions' });
 Transaction.belongsToMany(Service, { through: 'Services_Transactions' });
 


### PR DESCRIPTION
Bueno ahi estan las asociacines Bien!

si se fijan en el PGadmin, 
-la tabla de Reviews ahora tiene a userId y a serviceId.
-la tabla de Transactions ahora tiene a userId.

son las unicas a las que se les agrego una columna. transactions no teine a serviceId, porque su relacion es n a n, entonces se creo la tabla intermedia.

les dejo el link del video que explica: https://youtu.be/wgLo_0FL0yc?si=wHUDiEZCmgY7tpfS