### PR TITLE
Type Model + Filter

### DIFF
--- a/src/Controllers/serviceControllers/getServiceController.js
+++ b/src/Controllers/serviceControllers/getServiceController.js
@@ -1,15 +1,14 @@
 const { Service } = require('../../db');
-const { Op } = require("sequelize");
 const queryBuilder = require('../../Utils/queryBuilder');
 
-const getServiceController = async (id, order, min, max, keyword) => {
+const getServiceController = async ({ id, order, min, max, type }) => {
     if (id) {
         const service = await Service.findOne({ where: { id } });  
         if (!service) throw new Error ('No se encuentra el servicio solicitado.')
         return service;
     }
     else {
-        const query = queryBuilder(order, min, max, keyword);
+        const query = queryBuilder(order, min, max, type);
         const services = await Service.findAll({ ...query });
         if (!services.length) throw new Error ('No se encuentran servicios.');
         return services;

--- a/src/Controllers/serviceControllers/postServiceController.js
+++ b/src/Controllers/serviceControllers/postServiceController.js
@@ -1,6 +1,6 @@
-const { Service } = require('../../db');
+const { Service, Type } = require('../../db');
 const titleCase = require('../../Utils/titleCase');
-const cloudinary = require('../../cloudinary')
+const cloudinary = require('../../cloudinary');
 
 const postServiceController = async (serviceInfo) => {
     serviceInfo = {
@@ -9,8 +9,13 @@ const postServiceController = async (serviceInfo) => {
         photo: (await cloudinary.uploader.upload(serviceInfo.photo)).secure_url
     };
     const [service, created] = await Service.findOrCreate({ where: { name: serviceInfo.name }, defaults:{ ...serviceInfo } });
-    if (created) return service;
-    else throw new Error ('Ya existe un servicio con ese nombre.')
+    if (created) {
+        serviceInfo.types.forEach(async name => {
+            const type = await Type.findOne({ where: { name: titleCase(name) } });
+            await service.addType(type);
+        });
+        return service;
+    } else throw new Error ('Ya existe un servicio con ese nombre.');
 }
 
 module.exports = postServiceController;

--- a/src/Controllers/serviceControllers/postServiceController.js
+++ b/src/Controllers/serviceControllers/postServiceController.js
@@ -8,10 +8,10 @@ const postServiceController = async (serviceInfo) => {
     
     const [service, created] = await Service.findOrCreate({ where: { name: serviceInfo.name }, defaults:{ ...serviceInfo } });
     if (created) {
-        serviceInfo.types.forEach(async name => {
+        for (let name of serviceInfo.types) {
             const type = await Type.findOne({ where: { name: titleCase(name) } });
             await service.addType(type);
-        });
+        };
         return service;
     } else throw new Error ('Ya existe un servicio con ese nombre.');
 }

--- a/src/Controllers/serviceControllers/postServiceController.js
+++ b/src/Controllers/serviceControllers/postServiceController.js
@@ -3,11 +3,9 @@ const titleCase = require('../../Utils/titleCase');
 const cloudinary = require('../../cloudinary');
 
 const postServiceController = async (serviceInfo) => {
-    serviceInfo = {
-        ...serviceInfo,
-        name: await titleCase(serviceInfo.name),
-        photo: (await cloudinary.uploader.upload(serviceInfo.photo)).secure_url
-    };
+    if (serviceInfo.photo) serviceInfo.photo = (await cloudinary.uploader.upload(serviceInfo.photo)).secure_url;
+    if (serviceInfo.name) serviceInfo.name = titleCase(serviceInfo.name);
+    
     const [service, created] = await Service.findOrCreate({ where: { name: serviceInfo.name }, defaults:{ ...serviceInfo } });
     if (created) {
         serviceInfo.types.forEach(async name => {

--- a/src/Controllers/serviceControllers/putServiceController.js
+++ b/src/Controllers/serviceControllers/putServiceController.js
@@ -1,4 +1,4 @@
-const { Service } = require('../../db');
+const { Service, Type } = require('../../db');
 const titleCase = require('../../Utils/titleCase');
 
 const putServiceController = async (serviceInfo) => {
@@ -9,8 +9,14 @@ const putServiceController = async (serviceInfo) => {
         if (serviceInfo[property] && service.dataValues.hasOwnProperty(property))
         service[property] = serviceInfo[property];
     }
-
     await service.save();
+
+    await service.setTypes([]);
+
+    serviceInfo.types.forEach(async name => {
+        const type = await Type.findOne({ where: { name: titleCase(name) } });
+        await service.addType(type);
+    });
 
     return service;
 }

--- a/src/Controllers/serviceControllers/putServiceController.js
+++ b/src/Controllers/serviceControllers/putServiceController.js
@@ -13,10 +13,10 @@ const putServiceController = async (serviceInfo) => {
 
     await service.setTypes([]);
 
-    serviceInfo.types.forEach(async name => {
+    for (let name of serviceInfo.types) {
         const type = await Type.findOne({ where: { name: titleCase(name) } });
         await service.addType(type);
-    });
+    };
 
     return service;
 }

--- a/src/Controllers/typeControllers/deleteTypeController.js
+++ b/src/Controllers/typeControllers/deleteTypeController.js
@@ -1,0 +1,9 @@
+const { Service } = require('../../db');
+
+const deleteTypeController = async (id) => {
+    const service = await Service.destroy({ where: { id }});
+    if (!service) throw new Error ('No se encontró el servicio solicitado');
+    return 'Servicio eliminado correctamente.';
+}
+
+module.exports = deleteTypeController;

--- a/src/Controllers/typeControllers/deleteTypeController.js
+++ b/src/Controllers/typeControllers/deleteTypeController.js
@@ -1,6 +1,8 @@
 const { Type } = require('../../db');
+const titleCase = require('../../Utils/titleCase');
 
 const deleteTypeController = async (name) => {
+    name = titleCase(name);
     const type = await Type.destroy({ where: { name }});
     if (!type) throw new Error ('No se encontró el tipo de servicio solicitado');
     return 'Tipo de servicio eliminado correctamente.';

--- a/src/Controllers/typeControllers/deleteTypeController.js
+++ b/src/Controllers/typeControllers/deleteTypeController.js
@@ -1,9 +1,9 @@
-const { Service } = require('../../db');
+const { Type } = require('../../db');
 
-const deleteTypeController = async (id) => {
-    const service = await Service.destroy({ where: { id }});
-    if (!service) throw new Error ('No se encontró el servicio solicitado');
-    return 'Servicio eliminado correctamente.';
+const deleteTypeController = async (name) => {
+    const type = await Type.destroy({ where: { name }});
+    if (!type) throw new Error ('No se encontró el tipo de servicio solicitado');
+    return 'Tipo de servicio eliminado correctamente.';
 }
 
 module.exports = deleteTypeController;

--- a/src/Controllers/typeControllers/getTypeController.js
+++ b/src/Controllers/typeControllers/getTypeController.js
@@ -1,19 +1,9 @@
-const { Service } = require('../../db');
-const { Op } = require("sequelize");
-const queryBuilder = require('../../Utils/queryBuilder');
+const { Type } = require('../../db');
 
-const getTypeController = async (id, order, min, max, keyword) => {
-    if (id) {
-        const service = await Service.findOne({ where: { id } });  
-        if (!service) throw new Error ('No se encuentra el servicio solicitado.')
-        return service;
-    }
-    else {
-        const query = queryBuilder(order, min, max, keyword);
-        const services = await Service.findAll({ ...query });
-        if (!services.length) throw new Error ('No se encuentran servicios.');
-        return services;
-    }
+const getTypeController = async () => {
+    const types = await Type.findAll();
+    if (!types.length) throw new Error ('No se encuentran tipos de servicios.');
+    return types;
 }
 
 module.exports = getTypeController;

--- a/src/Controllers/typeControllers/getTypeController.js
+++ b/src/Controllers/typeControllers/getTypeController.js
@@ -1,0 +1,19 @@
+const { Service } = require('../../db');
+const { Op } = require("sequelize");
+const queryBuilder = require('../../Utils/queryBuilder');
+
+const getTypeController = async (id, order, min, max, keyword) => {
+    if (id) {
+        const service = await Service.findOne({ where: { id } });  
+        if (!service) throw new Error ('No se encuentra el servicio solicitado.')
+        return service;
+    }
+    else {
+        const query = queryBuilder(order, min, max, keyword);
+        const services = await Service.findAll({ ...query });
+        if (!services.length) throw new Error ('No se encuentran servicios.');
+        return services;
+    }
+}
+
+module.exports = getTypeController;

--- a/src/Controllers/typeControllers/postTypeController.js
+++ b/src/Controllers/typeControllers/postTypeController.js
@@ -1,16 +1,14 @@
-const { Service } = require('../../db');
+const { Type } = require('../../db');
 const titleCase = require('../../Utils/titleCase');
-const cloudinary = require('../../cloudinary')
 
-const postTypeController = async (serviceInfo) => {
-    serviceInfo = {
-        ...serviceInfo,
-        name: await titleCase(serviceInfo.name),
-        photo: (await cloudinary.uploader.upload(serviceInfo.photo)).secure_url
+const postTypeController = async (typeInfo) => {
+    typeInfo = {
+        ...typeInfo,
+        name: await titleCase(typeInfo.name),
     };
-    const [service, created] = await Service.findOrCreate({ where: { name: serviceInfo.name }, defaults:{ ...serviceInfo } });
-    if (created) return service;
-    else throw new Error ('Ya existe un servicio con ese nombre.')
+    const [type, created] = await Type.findOrCreate({ where: { name: typeInfo.name }, defaults:{ ...typeInfo } });
+    if (created) return type;
+    else throw new Error ('Ya existe un tipo de servicio con ese nombre.')
 }
 
 module.exports = postTypeController;

--- a/src/Controllers/typeControllers/postTypeController.js
+++ b/src/Controllers/typeControllers/postTypeController.js
@@ -1,0 +1,16 @@
+const { Service } = require('../../db');
+const titleCase = require('../../Utils/titleCase');
+const cloudinary = require('../../cloudinary')
+
+const postTypeController = async (serviceInfo) => {
+    serviceInfo = {
+        ...serviceInfo,
+        name: await titleCase(serviceInfo.name),
+        photo: (await cloudinary.uploader.upload(serviceInfo.photo)).secure_url
+    };
+    const [service, created] = await Service.findOrCreate({ where: { name: serviceInfo.name }, defaults:{ ...serviceInfo } });
+    if (created) return service;
+    else throw new Error ('Ya existe un servicio con ese nombre.')
+}
+
+module.exports = postTypeController;

--- a/src/Handlers/serviceHandlers/getServiceHandler.js
+++ b/src/Handlers/serviceHandlers/getServiceHandler.js
@@ -2,8 +2,8 @@ const getServiceController = require('../../Controllers/serviceControllers/getSe
 
 const getServiceHandler = async (req, res) => {
     try {
-        const { id, order, min, max, keyword } = req.query;
-        const response = await getServiceController(id, order, min, max, keyword);
+        const query = req.query;
+        const response = await getServiceController(query);
         res.status(200).json(response);
     } catch (err) {
         res.status(404).json(err.message);

--- a/src/Handlers/typeHandlers/deleteTypeHandler.js
+++ b/src/Handlers/typeHandlers/deleteTypeHandler.js
@@ -1,0 +1,13 @@
+const deleteTypeController = require('../../Controllers/typeControllers/deleteTypeController');
+
+const deleteTypeHandler = async (req, res) => {
+    try {
+        const { id } = req.params;
+        const response = await deleteTypeController(id);
+        res.status(200).json(response);
+    } catch (err) {
+        res.status(400).json(err.message);
+    }
+}
+
+module.exports = deleteTypeHandler;

--- a/src/Handlers/typeHandlers/deleteTypeHandler.js
+++ b/src/Handlers/typeHandlers/deleteTypeHandler.js
@@ -2,8 +2,8 @@ const deleteTypeController = require('../../Controllers/typeControllers/deleteTy
 
 const deleteTypeHandler = async (req, res) => {
     try {
-        const { id } = req.params;
-        const response = await deleteTypeController(id);
+        const { name } = req.params;
+        const response = await deleteTypeController(name);
         res.status(200).json(response);
     } catch (err) {
         res.status(400).json(err.message);

--- a/src/Handlers/typeHandlers/getTypeHandler.js
+++ b/src/Handlers/typeHandlers/getTypeHandler.js
@@ -1,0 +1,13 @@
+const getTypeController = require('../../Controllers/typeControllers/getTypeController');
+
+const getTypeHandler = async (req, res) => {
+    try {
+        const { id, order, min, max, keyword } = req.query;
+        const response = await getTypeController(id, order, min, max, keyword);
+        res.status(200).json(response);
+    } catch (err) {
+        res.status(404).json(err.message);
+    }
+}
+
+module.exports = getTypeHandler;

--- a/src/Handlers/typeHandlers/getTypeHandler.js
+++ b/src/Handlers/typeHandlers/getTypeHandler.js
@@ -2,8 +2,7 @@ const getTypeController = require('../../Controllers/typeControllers/getTypeCont
 
 const getTypeHandler = async (req, res) => {
     try {
-        const { id, order, min, max, keyword } = req.query;
-        const response = await getTypeController(id, order, min, max, keyword);
+        const response = await getTypeController();
         res.status(200).json(response);
     } catch (err) {
         res.status(404).json(err.message);

--- a/src/Handlers/typeHandlers/postTypeHandler.js
+++ b/src/Handlers/typeHandlers/postTypeHandler.js
@@ -2,8 +2,8 @@ const postTypeController = require('../../Controllers/typeControllers/postTypeCo
 
 const postTypeHandler = async (req, res) => {
     try {
-        const serviceInfo = req.body;
-        const response = await postTypeController(serviceInfo);
+        const typeInfo = req.body;
+        const response = await postTypeController(typeInfo);
         res.status(201).json(response);
     } catch (err) {
         res.status(400).json(err.message);

--- a/src/Handlers/typeHandlers/postTypeHandler.js
+++ b/src/Handlers/typeHandlers/postTypeHandler.js
@@ -1,0 +1,13 @@
+const postTypeController = require('../../Controllers/typeControllers/postTypeController');
+
+const postTypeHandler = async (req, res) => {
+    try {
+        const serviceInfo = req.body;
+        const response = await postTypeController(serviceInfo);
+        res.status(201).json(response);
+    } catch (err) {
+        res.status(400).json(err.message);
+    }
+}
+
+module.exports = postTypeHandler;

--- a/src/Models/Service.js
+++ b/src/Models/Service.js
@@ -20,10 +20,6 @@ module.exports = (sequelize)=>{
             type: DataTypes.INTEGER,
             allowNull: false,
         },
-        keyWord: {
-            type: DataTypes.ENUM('cv', 'perfil', 'practica', 'busqueda'),
-            allowNull: false
-        },
         photo: {
             type: DataTypes.STRING,
             defaultValue: 'https://res.cloudinary.com/dk4amlgtk/image/upload/v1698452423/wl2rucr4t8h4pyq8b6w0.png'

--- a/src/Models/Type.js
+++ b/src/Models/Type.js
@@ -1,0 +1,16 @@
+const { DataTypes } = require('sequelize');
+
+module.exports = (sequelize)=>{
+    sequelize.define('Type', {
+        id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            defaultValue: DataTypes.UUIDV4,
+        },
+        name: {
+            type: DataTypes.STRING,
+            allowNull: false,
+            unique: true,
+        },
+    })
+}

--- a/src/Routes/mainRouter.js
+++ b/src/Routes/mainRouter.js
@@ -1,6 +1,7 @@
 const Router = require('express');
 
 const userRouter = require('./userRouter');
+const typeRouter = require('./typeRouter');
 const reviewRouter = require('./reviewRouter');
 const serviceRouter = require('./serviceRouter');
 const transactionRouter = require('./transactionRouter');
@@ -8,6 +9,7 @@ const transactionRouter = require('./transactionRouter');
 const mainRouter = Router();
 
 mainRouter.use('/user', userRouter);
+mainRouter.use('/type', typeRouter);
 mainRouter.use('/review', reviewRouter);
 mainRouter.use('/service', serviceRouter);
 mainRouter.use('/transaction', transactionRouter);

--- a/src/Routes/typeRouter.js
+++ b/src/Routes/typeRouter.js
@@ -1,0 +1,15 @@
+const Router = require('express');
+
+const URL = '../Handlers/typeHandlers/';
+
+const getTypehandler = require(URL + 'getTypehandler');
+const postTypeHandler = require(URL + 'postTypeHandler');
+const deleteTypeHandler = require(URL + 'deleteTypeHandler');
+
+const TypeRouter = Router();
+
+typeRouter.get('/', getTypehandler);
+typeRouter.post('/', postTypeHandler);
+typeRouter.delete('/:id', deleteTypeHandler);
+
+module.exports = TypeRouter;

--- a/src/Routes/typeRouter.js
+++ b/src/Routes/typeRouter.js
@@ -10,6 +10,6 @@ const typeRouter = Router();
 
 typeRouter.get('/', getTypehandler);
 typeRouter.post('/', postTypeHandler);
-typeRouter.delete('/:id', deleteTypeHandler);
+typeRouter.delete('/:name', deleteTypeHandler);
 
 module.exports = typeRouter;

--- a/src/Routes/typeRouter.js
+++ b/src/Routes/typeRouter.js
@@ -6,10 +6,10 @@ const getTypehandler = require(URL + 'getTypehandler');
 const postTypeHandler = require(URL + 'postTypeHandler');
 const deleteTypeHandler = require(URL + 'deleteTypeHandler');
 
-const TypeRouter = Router();
+const typeRouter = Router();
 
 typeRouter.get('/', getTypehandler);
 typeRouter.post('/', postTypeHandler);
 typeRouter.delete('/:id', deleteTypeHandler);
 
-module.exports = TypeRouter;
+module.exports = typeRouter;

--- a/src/Utils/queryBuilder.js
+++ b/src/Utils/queryBuilder.js
@@ -1,14 +1,15 @@
-const { Op } = require("sequelize");
+const { Type } = require('../db');
+const { Op } = require('sequelize');
+const titleCase = require('../Utils/titleCase');
 
-const queryBuilder = (order, min, max, keyword) => {
+const queryBuilder = (order, min, max, type) => {
     let query = {};
-    if (min) query = { ...query, where: { price: { [Op.gte]: min } } };
-    if (max) query = { ...query, where: { price: { [Op.lte]: max } } };
     if (min && max) query = { ...query, where: { price: { [Op.between]: [min, max] } } };
-
-    // if (keyword) query = { ...query, where: { keyWord: { [Op.contains]: ['cv'] } } }
-    // if (keyword && min && max) query = { ...query, where: { ...query.where, keyWord: { [Op.contains]: ['cv'] } } }
-
+    else {
+        if (min) query = { ...query, where: { price: { [Op.gte]: min } } };
+        if (max) query = { ...query, where: { price: { [Op.lte]: max } } };
+    }
+    if (type) query = { ...query, include: [{ model: Type, where: { name: titleCase(type) } }] };
     query = { ...query, order: [[ 'price', order ? order : 'ASC' ]]};
     return query;
 }

--- a/src/db.js
+++ b/src/db.js
@@ -4,6 +4,7 @@ const { DB_USER, DB_PASSWORD, DB_HOST, DB_NAME } = process.env;
 
 //Models
 const userModel = require('./Models/User')
+const typeModel = require('./Models/Type')
 const reviewModel = require('./Models/Review')
 const serviceModel = require('./Models/Service')
 const transactionModel = require('./Models/Transaction')
@@ -13,12 +14,14 @@ const sequelize = new Sequelize(
     { logging: false, native: false });
 
 userModel(sequelize);
+typeModel(sequelize);
 reviewModel(sequelize);
 serviceModel(sequelize);
 transactionModel(sequelize);
 
 const {
     User,
+    Type,
     Review,
     Service,
     Transaction
@@ -33,6 +36,8 @@ Service.hasMany(Review, {as: "reviews", foreignKey: "serviceId"});
 Review.belongsTo(Service, {as: "service"});
 Service.belongsToMany(Transaction, { through: 'Services_Transactions' });
 Transaction.belongsToMany(Service, { through: 'Services_Transactions' });
+Service.belongsToMany(Type, { through: 'Services_Types' });
+Type.belongsToMany(Service, { through: 'Services_Types' });
 
 module.exports = {
     ...sequelize.models,


### PR DESCRIPTION
Ya se pueden crear tipos de servicios, editarlos, eliminarlos. Todo ok.

Al crear un servicio, dentro del body debería llegar un array "types" con los nombres de los servicios, para asociarlos.
Al editar un servicio lo mismo; si no llega nada, no va a tener asociaciones.

Los filtros combinados ya funcionan de 10, creo que probé todas las posibilidades y no me dió ningún error. Lo que podríamos mejorar es que reciba varios tipos. No lo hago porque Axel dijo que por ahora había hecho un selector que permite una sola selección, pero si modifican eso es simplemente editar el queryBuilder un poquito.