### PR TITLE
agregue x-forwarded-for

### DIFF
--- a/src/Controllers/configControllers/getConfigController.js
+++ b/src/Controllers/configControllers/getConfigController.js
@@ -1,12 +1,14 @@
 const  axios  = require('axios');
 const {Config} = require('../../db.js')
 
-const getConfigController = async () => {
+const getConfigController = async (ip) => {
 
-    const {data} = await axios.get('https://ipinfo.io')
+    const {data} = await axios.get(`https://ipinfo.io/${ip}`)
+    
     const country = {country: data.country}
+
     const config = await Config.findOne();
-   
+
     if(config && country){
         return {...config.dataValues, ...country};
     }

--- a/src/Handlers/configHandlers/getConfigHandler.js
+++ b/src/Handlers/configHandlers/getConfigHandler.js
@@ -2,7 +2,8 @@ const getConfigController = require("../../Controllers/configControllers/getConf
 
 const getConfigHandler = async (req, res) => {
     try {
-        const config = await getConfigController()
+        const userIp = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
+        const config = await getConfigController(userIp)
         res.status(200).json(config);
     } catch (error) {
         res.status(404).json(error.message)


### PR DESCRIPTION
se implemento  x-Forwarded-for en las solicitudes del backend para obtener la dirección IP real del cliente. Además, se utilizó req.connection.remoteaddress como alternativa para manejar casos en los que el encabezado no está presente. con esto se busca una mayor precisión para obtener la dirección IP del usuario.

X-Forwarded-For: Es un encabezado HTTP utilizado para identificar la dirección IP real del cliente cuando una solicitud web pasa a través de intermediarios, como proxies. 

req.connection: En el contexto de Node.js, req.connection es un objeto que proporciona información sobre la conexión de la solicitud. req.connection.remoteAddress se usa para obtener la dirección IP del cliente. Este enfoque se implementa para manejar casos en los que el encabezado X-Forwarded-For no está presente.